### PR TITLE
update project.json for service worker config due to angular 20's update

### DIFF
--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -15,6 +15,7 @@
         "polyfills": ["zone.js"],
         "tsConfig": "apps/web/tsconfig.app.json",
         "inlineStyleLanguage": "scss",
+        "serviceWorker": "apps/web/ngsw-config.json",
         "assets": [
           {
             "glob": "**/*",
@@ -37,9 +38,7 @@
               "maximumError": "8kb"
             }
           ],
-          "outputHashing": "all",
-          "serviceWorker": true,
-          "ngswConfigPath": "apps/web/ngsw-config.json"
+          "outputHashing": "all"
         },
         "development": {
           "optimization": false,


### PR DESCRIPTION
La build Netlify cassait parce que l’option attendue par l’exécuteur Angular a changé : le schéma 20.x n’accepte plus ngswConfigPath et s’attend à ce que serviceWorker contienne directement le chemin du fichier de config. J’ai mis à jour apps/web/project.json:13-23 pour pointer vers apps/web/ngsw-config.json avec serviceWorker: "apps/web/ngsw-config.json".